### PR TITLE
Add ansible-specdoc & update Ubuntu 22 support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 wheel
 linode_api4
 ansible
+ansible-specdoc==0.0.12
 passlib==1.7.4
 polling==0.3.2
 yamllint==1.26.2

--- a/roles/mongodb/tasks/install.yml
+++ b/roles/mongodb/tasks/install.yml
@@ -31,13 +31,13 @@
  
 - name: importing signing key
   apt_key:
-    url: https://www.mongodb.org/static/pgp/server-5.0.asc 
+    url: https://www.mongodb.org/static/pgp/server-6.0.asc 
     state: present
 
 - name: adding mongodb repository
   apt_repository:
-    repo: deb http://repo.mongodb.org/apt/debian bullseye/mongodb-org/5.0 main
-    filename: mongodb-org-5.0
+    repo: deb http://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/6.0 multiverse
+    filename: mongodb-org-6.0
     state: present
 
 - name: updating repos


### PR DESCRIPTION
Needed to update to mongo v6 in order to get this working on ubuntu 22